### PR TITLE
Fixed numa node bug

### DIFF
--- a/rdma.go
+++ b/rdma.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"strconv"
+	"strings"
 
 	"github.com/hustcat/k8s-rdma-device-plugin/ibverbs"
 	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1beta1"
@@ -124,7 +125,10 @@ func getRdmaDeviceNumaNode(name string) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	return strconv.Atoi(string(data))
+
+	dataStr := string(data)
+	dataStr = strings.TrimSuffix(dataStr, "\n")
+	return strconv.Atoi(dataStr)
 }
 
 func deviceExists(devs []*pluginapi.Device, id string) bool {


### PR DESCRIPTION
on CentOS 7.4.1708, it will output the following error:

[main.go:35] Error to get IB device: strconv.Atoi: parsing "1\n": invalid syntax

this commit fixed it